### PR TITLE
Correct prediction for knn in 07_Non-Linear_Reg.R

### DIFF
--- a/inst/chapters/07_Non-Linear_Reg.R
+++ b/inst/chapters/07_Non-Linear_Reg.R
@@ -151,7 +151,7 @@ knnTune
 
 plot(knnTune)
 
-testResults$Knn <- predict(svmRTune, solTestXtrans[, names(knnDescr)])
+testResults$Knn <- predict(knnTune, solTestXtrans[, names(knnDescr)])
 
 ################################################################################
 ### Session Information


### PR DESCRIPTION
When saving the prediction from knn, the code uses the results of the SVM training instead.  change to 'knntune' to make the prediction to save into testResults.